### PR TITLE
Downloader: allow use of custom request header and ignoring of status code errors.

### DIFF
--- a/src/network/Downloader.cpp
+++ b/src/network/Downloader.cpp
@@ -315,6 +315,41 @@ namespace ktl {
 	//
 	SPRIG_KRKR_NATIVE_PROP_DECL_VARIANT(Downloader, onFinished, getOnFinished, setOnFinished);
 
+	//
+	//  HACK: カスタムヘッダ設定
+	//
+	SPRIG_KRKR_BEGIN_NATIVE_METHOD_DECL(setCustomHeader)
+	{
+		TJS_GET_NATIVE_INSTANCE(this_, Downloader);
+		SPRIG_KRKR_NUMPARAMS_CHECK(1);
+		switch (SPRIG_KRKR_ARG_TYPE(0)) {
+		case tvtString:
+			SPRIG_KRKR_INVOKE_RESULT_SET(
+				this_->setCustomHeader(SPRIG_KRKR_ARG_STRING(0))
+				);
+			break;
+		default:
+			return TJS_E_INVALIDPARAM;
+		}
+		return TJS_S_OK;
+	}
+	SPRIG_KRKR_END_NATIVE_METHOD_DECL(setCustomHeader);
+
+	SPRIG_KRKR_BEGIN_NATIVE_METHOD_DECL(clearCustomHeader)
+	{
+		TJS_GET_NATIVE_INSTANCE(this_, Downloader);
+		SPRIG_KRKR_INVOKE_RESULT_SET(
+			this_->clearCustomHeader()
+			);
+		return TJS_S_OK;
+	}
+	SPRIG_KRKR_END_NATIVE_METHOD_DECL(clearCustomHeader);
+
+	//
+	//  HACK: processStatusCodeError
+	//
+	SPRIG_KRKR_NATIVE_PROP_DECL_VARIANT(Downloader, processStatusCodeError, getProcessStatusCodeError, setProcessStatusCodeError);
+
 	SPRIG_KRKR_END_CREATE_NATIVE_CLASS();
 #undef TJS_NATIVE_CLASSID_NAME
 }	// namespace ktl

--- a/src/network/DownloaderDecl.hpp
+++ b/src/network/DownloaderDecl.hpp
@@ -280,6 +280,22 @@ namespace ktl {
 		//
 		tTJSVariant getOnFinished() const;
 		void setOnFinished(tTJSVariant const& func);
+
+		//  HACK: カスタムヘッダ設定
+	public:
+		bool setCustomHeader(tjs_char const* source);
+		bool clearCustomHeader();
+
+	private:
+		boost::shared_ptr<std::string> custom_header_;
+
+		//  HACK: processStatusCodeError
+	public:
+		void setProcessStatusCodeError(bool value);
+		bool getProcessStatusCodeError() const;
+
+	private:
+		bool process_status_code_error_;
 	};
 
 	//
@@ -409,5 +425,13 @@ namespace ktl {
 		//
 		tTJSVariant getOnFinished() const;
 		void setOnFinished(tTJSVariant const& func);
+
+		//  HACK: カスタムヘッダ設定
+		bool setCustomHeader(tTJSVariantString const* source);
+		bool clearCustomHeader();
+
+		//  HACK: processStatusCodeError
+		void setProcessStatusCodeError(tTVInteger value);
+		bool getProcessStatusCodeError() const;
 	};
 }	// namespace ktl


### PR DESCRIPTION
KTL NetworkプラグインのDownloaderクラスに、二つのマイナー機能を追加しました。

１、リクエストのヘッダに任意の文字列を追加できるよう、
Downloader.setCustomHeader(string)
Downloader.clearCustomHeader()
を実装しました。

これを使うと、Content-Typeなどのヘッダフィールドが指定できます。

２、失敗のStatus Codeが返されても、リスポンスのBodyを獲得できるように、
Downloader.processStatusCodeError = true | false;
を実装しました。

これをfalseに設定すると、たとえ4XXなどのStatus Codeが返されても、リスポンスの解析とBodyの処理を続けます。

コードのほとんどがコピペなので、あまりきれいとは言い難いが、Web Serviceをアクセスする上で有用な機能だと思います。本家にマージしてもらえるとうれしいです。
